### PR TITLE
Fixed issue with initialize function calling contract address and not msg.sender address

### DIFF
--- a/contracts/ATS.sol
+++ b/contracts/ATS.sol
@@ -62,7 +62,7 @@ interface ATS {
     event Created(
         uint128 indexed     _totalSupply,
         /// This is a horrible name I know, up for debate
-        address indexed     _specialAddress);
+        address indexed     _creator);
 
     event Sent(
         address indexed     _operator,

--- a/contracts/ATSImpl.sol
+++ b/contracts/ATSImpl.sol
@@ -47,13 +47,15 @@ contract ATSBase is ATS, ERC20, AionInterfaceImplementer {
         mTotalSupply = _totalSupply;
         mGranularity = _granularity;
 
+        initialize(_totalSupply);
+
         // register onto CIR
         setInterfaceDelegate("AIP004Token", this);
     }
 
     function initialize(uint128 _totalSupply) internal {
-        mBalances[address(this)] = _totalSupply;
-        Created(_totalSupply, address(this));
+        mBalances[msg.sender] = _totalSupply;
+        Created(_totalSupply, msg.sender);
     }
 
     /* -- ERC777 Interface Implementation -- */


### PR DESCRIPTION
- Fixed the issue where the contract address was being called within the `initialize` function.

- The `initialize` was also not being called within the constructor. 